### PR TITLE
support data.attrs.id

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -436,6 +436,40 @@ test(
 )
 
 test(
+  'reads `id` attribute from data object',
+  io,
+  [
+    h('h2', { attrs: { id: '2a' } }, '2a'),
+    h('h2', { attrs: { id: '2b' } }, '2b')
+  ],
+  h('ul', [
+    h('li', [
+      h('a', { attrs: { href: '#2a' } }, '2a')
+    ]),
+    h('li', [
+      h('a', { attrs: { href: '#2b' } }, '2b')
+    ])
+  ])
+)
+
+test(
+  'prefers `id` attribute from data object',
+  io,
+  [
+    h('h2#foo', { attrs: { id: '2a' } }, '2a'),
+    h('h2#bar', { attrs: { id: '2b' } }, '2b')
+  ],
+  h('ul', [
+    h('li', [
+      h('a', { attrs: { href: '#2a' } }, '2a')
+    ]),
+    h('li', [
+      h('a', { attrs: { href: '#2b' } }, '2b')
+    ])
+  ])
+)
+
+test(
   'big and complex',
   io,
   [

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,10 +15,12 @@ const snabbdomToc = (content: VNode[]): VNode => {
   } as { [depth: number]: VNode | null }
 
   for (const header of headers) {
-    const { tagName, id } = selectorParser(header)
+    const { tagName, id: selectorId } = selectorParser(header)
+    const attrsId = header.data && header.data.attrs && header.data.attrs.id as string
     const hX = Number(tagName.slice(1, 2))
     const a = decontextify(header)
     a.sel = 'a'
+    const id = attrsId || selectorId
     if (id) {
       a.data = { attrs: { href: '#' + id } }
     }


### PR DESCRIPTION
In snabbdom, there are two places where an `id` can be in a VNode. That I know of.

One is the selector and the other is the `data.attrs.id`.

This adds support and preference to the latter.