### PR TITLE
Disallow CI failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: node_js
 node_js:
   - node
   - lts/*
-matrix:
-  allow_failures:
-    - node_js: node
 before_install:
   # package-lock.json was introduced in npm@5
   - npm install -g npm@5


### PR DESCRIPTION
When Node.js releases a v9.x that has an actually working npm, this will pass CI.

And then it should be merged.